### PR TITLE
Расширение кнопок вперед/назад в списке тредов и списке изображений

### DIFF
--- a/res/layout/image_gallery_view.xml
+++ b/res/layout/image_gallery_view.xml
@@ -11,33 +11,37 @@
         android:layout_height="0dip"
         android:layout_weight="1" />
     
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/image_gallery_bar"
         android:layout_width="fill_parent"
-        android:layout_height="@dimen/navigation_button_size" >
+        android:layout_height="@dimen/navigation_button_size"
+        android:weightSum="100"
+        android:orientation="horizontal">
 
         <ImageButton
             android:id="@+id/image_gallery_prev"
-            android:layout_width="@dimen/navigation_button_size"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/navigation_button_size"
-            android:layout_alignParentLeft="true"
             android:background="@null"
+            android:scaleType="fitStart"
+            android:layout_weight="50"
             android:src="?iconBack" />
 
         <TextView
             android:id="@+id/image_gallery_text"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
+            android:layout_height="fill_parent"
+            android:gravity="center_vertical"
             android:textAppearance="?android:attr/textAppearanceLarge" />
 
         <ImageButton
             android:id="@+id/image_gallery_next"
-            android:layout_width="@dimen/navigation_button_size"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/navigation_button_size"
-            android:layout_alignParentRight="true"
             android:background="@null"
+            android:scaleType="fitEnd"
+            android:layout_weight="50"
             android:src="?iconForward" />
-    </RelativeLayout>
+    </LinearLayout>
     
 </LinearLayout>

--- a/res/layout/threads_list_view.xml
+++ b/res/layout/threads_list_view.xml
@@ -42,34 +42,37 @@
             android:visibility="gone" />
     </FrameLayout>
 
-    <RelativeLayout
+    <LinearLayout
         android:id="@+id/threads_navigation_bar"
         android:layout_width="fill_parent"
-        android:layout_height="@dimen/navigation_button_size" >
+        android:layout_height="@dimen/navigation_button_size"
+        android:weightSum="100">
 
         <ImageButton
             android:id="@+id/threads_prev_page"
-            android:layout_width="@dimen/navigation_button_size"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/navigation_button_size"
-            android:layout_alignParentLeft="true"
             android:background="@null"
-            android:src="?iconBack" />
+            android:src="?iconBack"
+            android:scaleType="fitStart"
+            android:layout_weight="50"/>
 
         <TextView
             android:id="@+id/threads_page_number"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
+            android:layout_height="fill_parent"
+            android:gravity="center_vertical"
             android:textAppearance="?android:attr/textAppearanceLarge" />
 
         <ImageButton
             android:id="@+id/threads_next_page"
-            android:layout_width="@dimen/navigation_button_size"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/navigation_button_size"
-            android:layout_alignParentRight="true"
             android:background="@null"
-            android:src="?iconForward" />
-    </RelativeLayout>
+            android:src="?iconForward"
+            android:scaleType="fitEnd"
+            android:layout_weight="50"/>
+    </LinearLayout>
     
     <RelativeLayout
         android:id="@+id/threads_catalog_bar"

--- a/src/com/vortexwolf/chan/activities/ThreadsListActivity.java
+++ b/src/com/vortexwolf/chan/activities/ThreadsListActivity.java
@@ -179,9 +179,9 @@ public class ThreadsListActivity extends BaseListActivity {
         ImageButton nextButton = (ImageButton) this.findViewById(R.id.threads_next_page);
         ImageButton prevButton = (ImageButton) this.findViewById(R.id.threads_prev_page);
         if (this.mPageNumber == 0) {
-            prevButton.setVisibility(View.GONE);
+            prevButton.setVisibility(View.INVISIBLE);
         } else if (this.mPageNumber == 19) {
-            nextButton.setVisibility(View.GONE);
+            nextButton.setVisibility(View.INVISIBLE);
         }
 
         prevButton.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Приветствую.
Хочу обратить ваше внимание на данную область:
![unnamed](https://cloud.githubusercontent.com/assets/2063519/4434897/085cfeb8-472a-11e4-98c9-3b6901c5a176.png)

Как мне кажется, она расходуется впустую. Уже давно меня мучают кнопки около нее. В них чертовски трудно попасть, а правая еще и граничит с hardware back-button. Если коротко - боль и страдание, если пытаться что-либо листать на ходу.
В данном реквесте предвалаю вариант решения данной проблемы через расширение данных кнопок до центрального TextView. Не претендую на лучшую реализацию, т.к. не трогал Android-платформу уже очень давно, но, вроде бы верстка не изгадилась и все норм.
В дополнение к такой реализации неплохо бы подошла анимация нажатия на кнопку - она "покажет" пользователю реальный размер кнопки, но это уже на усмотрение меинтейнера. Призываю комментарии и критику.
